### PR TITLE
lookup the store using `service:store` where available

### DIFF
--- a/ember-console-helpers.js
+++ b/ember-console-helpers.js
@@ -56,7 +56,9 @@
 
       // Return a reference to the store instance
       store: function(app) {
-        return this.container(app).lookup('store:main');
+        // NOTE: `service:store` was added in Ember Data 2.0
+        return this.container(app).lookup('service:store')
+          || this.container(app).lookup('store:main');
       }
     },
 


### PR DESCRIPTION
In Ember Data 2.0, `store:main` no longer works, and we need to use `service:store` instead.

Related: https://github.com/emberjs/data/pull/3286